### PR TITLE
Adding cross domain linking for google anaytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,12 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'UA-86252748-1', { 'optimize_id': 'GTM-N4KZFL3'});
+      gtag('config', 'UA-86252748-1', { 
+          'optimize_id': 'GTM-N4KZFL3',
+          'linker': {
+              'domains': ['ijjico.myshopify.com']
+          }
+      });      
     </script>
   </head>
   <body id='body'>


### PR DESCRIPTION
In order for google analytics to transfer sessions on ijji.co to ijjico.myshopify.com, we need to configure google analytics to pass the clientId on outbound links.