### PR TITLE
Switching to analytics.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       ga('create', 'UA-86252748-1', 'auto', {'allowLinker': true});
       ga('require', 'GTM-N4KZFL3');
       ga('require', 'linker');
-      ga('linker:autoLink', ['myshopify.com']);
+      ga('linker:autoLink', ['myshopify.com'], true);
       ga('send', 'pageview');
     </script>
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/index.html
+++ b/index.html
@@ -2,11 +2,24 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-86252748-1', 'auto', {'allowLinker': true});
+      ga('require', 'GTM-N4KZFL3');
+      ga('require', 'linker');
+      ga('linker:autoLink', ['myshopify.com']);
+      ga('send', 'pageview');
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>IJJI</title>
     <!-- <script type='text/javascript' src='http://app.backinstock.org//widget//6048_1499930253.js?v=5%5Cu0026shop=ijjico.myshopify.com'></script> -->
     <!-- <script type='text/javascript' id='BIS'  src='https://app.backinstock.org/widget/6048_1499930253.js'></script> -->
     <!-- <script type='text/javascript' id='BIS'  src='/static/BIS.js'></script> -->
+    <!--
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-86252748-1"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -20,6 +33,7 @@
           }
       });      
     </script>
+    -->
   </head>
   <body id='body'>
     <div id="app"></div>


### PR DESCRIPTION
Cross-domain linking is not working correctly with the gtag.js version of Google Analytics. Hopefully switching to the older analytics.js library will resolve this, since this is what Shopify uses.