### PR TITLE
Changing checkout button link to _self

### DIFF
--- a/src/components/Cart.vue
+++ b/src/components/Cart.vue
@@ -32,7 +32,7 @@
         <div class='right'>${{total}}</div>
         <div class='clear-both'></div>
       </div>
-      <a class='checkoutButton' target='_blank' :href='cart.webUrl'>Checkout</a>
+      <a class='checkoutButton' target='_self' :href='cart.webUrl'>Checkout</a>
     </div>
     <div v-else>
     Cart is empty


### PR DESCRIPTION
I discovered that the cross domain tracking in Google Analytics was breaking because a new tab was being opened by the Checkout button. By changing the button to open in the same tab, the clientId is transferred correctly.